### PR TITLE
Bugfix Yahoo Endpoint

### DIFF
--- a/src/main/java/com/ritaja/xchangerate/endpoint/YahooEndpoint.java
+++ b/src/main/java/com/ritaja/xchangerate/endpoint/YahooEndpoint.java
@@ -84,9 +84,11 @@ public class YahooEndpoint extends EndpointFactory {
 		// JSONArray is not iterable, hence the code
 		for (int i = 0; i < resources.length(); ++i) {
 			JSONObject field = resources.getJSONObject(i).getJSONObject("resource").getJSONObject("fields");
+			if(field.length() > 0){
 			if (field.getString("name").equalsIgnoreCase("USD/" + currency.toString())) {
 				rate.put(currency, new BigDecimal(field.getString("price")));
 				return Long.parseLong(field.getString("ts"), 10) * 1000;
+			}
 			}
 		}
 		throw new CurrencyNotSupportedException("currency: " + currency + " is not supported by Yahoo endpoint");


### PR DESCRIPTION
In the currency JSON have empty fields like this: 
 {
"resource" : { 
"classname" : "Quote",
"fields" : { 
}

It's crashes on  field.getString("name"), because JSONObject is empty.
I've add check field.lentfht to skip this line